### PR TITLE
fix sep for import of csv and tsv files

### DIFF
--- a/src/components/Object/Import.vue
+++ b/src/components/Object/Import.vue
@@ -47,7 +47,7 @@ export default {
     connector: upload
     table: {table}
     type: csv
-    sep: "\\\\s+|,|;"
+    sep: "\\\\t|,|;"
     encoding: "utf8"`
     }
   },

--- a/src/components/Object/New.vue
+++ b/src/components/Object/New.vue
@@ -64,7 +64,7 @@ export default {
     connector: upload
     table: {table}
     type: csv
-    sep: "\\\\s+|,|;"
+    sep: "\\\\t|,|;"
     encoding: "utf8"`,
         recipe: `recipes:
   {}:


### PR DESCRIPTION
"\\s+|;|," separator is week, replace \s+ with \t which is far more reliable in general cases